### PR TITLE
Changed namespace from 'NetworkConnection' to 'NetworkConnections' to…

### DIFF
--- a/NetworkConnection/NetworkConnection.cs
+++ b/NetworkConnection/NetworkConnection.cs
@@ -1,10 +1,10 @@
-﻿using NetworkConnection.Win32Objects;
+﻿using NetworkConnections.Win32Objects;
 using System;
 using System.ComponentModel;
 using System.Net;
 using System.Runtime.InteropServices;
 
-namespace NetworkConnection
+namespace NetworkConnections
 {
     /// <summary>
     /// Represents a network connection along with authentication to a network share.

--- a/NetworkConnection/Win32Objects/NetResource.cs
+++ b/NetworkConnection/Win32Objects/NetResource.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace NetworkConnection.Win32Objects
+namespace NetworkConnections.Win32Objects
 {
     /// <summary>
     /// The net resource.

--- a/NetworkConnection/Win32Objects/ResourceDisplaytype.cs
+++ b/NetworkConnection/Win32Objects/ResourceDisplaytype.cs
@@ -1,4 +1,4 @@
-﻿namespace NetworkConnection.Win32Objects
+﻿namespace NetworkConnections.Win32Objects
 {
     /// <summary>
     /// The resource displaytype.

--- a/NetworkConnection/Win32Objects/ResourceScope.cs
+++ b/NetworkConnection/Win32Objects/ResourceScope.cs
@@ -1,4 +1,4 @@
-﻿namespace NetworkConnection.Win32Objects
+﻿namespace NetworkConnections.Win32Objects
 {
     /// <summary>
     /// The resource scope.

--- a/NetworkConnection/Win32Objects/ResourceType.cs
+++ b/NetworkConnection/Win32Objects/ResourceType.cs
@@ -1,4 +1,4 @@
-﻿namespace NetworkConnection.Win32Objects
+﻿namespace NetworkConnections.Win32Objects
 {
     /// <summary>
     /// The resource type.


### PR DESCRIPTION
… prevent naming conflict with the NetworkConnection class.

This circumvents the need to utilize an alias to to prevent the following compiler error:
“NetworkConnection” is ambiguous between NetworkConnection and NetworkConnection.

In essence, this change allows for: 
```
using NetworkConnections;
var conn = new NetworkConnection();
```

instead of:
```
using NC = NetworkConnection;
var conn = new NC.NetworkConnection();
```